### PR TITLE
feature/7 Lister les apprenants et les roles

### DIFF
--- a/reverse/client/missy.py
+++ b/reverse/client/missy.py
@@ -64,5 +64,20 @@ class Missy(commands.Cog):
 			else:
 				await ctx.send("This role is unused.")
 
+	@commands.command()
+	async def members(self, ctx, *args):
+		ctx = Context(ctx)
+		guild = ctx.guild
+		_kwargs, _args = utils.parse_args(args)
+		if("role" in _kwargs.keys()):
+			r_id = _kwargs["role"][3:-1]
+			_m = utils.getAllMembers(guild, int(r_id))
+
+			if(len(_m) >= 1):
+				for v in _m:
+					await ctx.send("User: {}".format(v))
+			else:
+				await ctx.send("This role is unused.")
+
 def setup(bot):
 	bot.add_cog(Missy(bot))


### PR DESCRIPTION
***Hum j'ai surement fail mon coup car j'ai fait une branche à partir de rework9000 et non MissyCore. Dites moi si vous voulez que je change***

Ajout d'une commande **préfixe**getLearners

Elle récupère la liste des rôles sur le serveur et tous les membres.
Elle affiche un message dans le channel où la commande est exécutées sur le format

Rôles:
role.name role.id

Membres:
member.name member.id member.roles